### PR TITLE
Use param torrentname for searching

### DIFF
--- a/search_tehconnection.py
+++ b/search_tehconnection.py
@@ -10,7 +10,7 @@ log = logging.getLogger('search_tehconnection')
 
 class SearchTC(object):
   def search(self, task, entry, config=None):
-    url = "https://tehconnection.eu/torrents.php?searchstr=" + entry["imdb_id"];
+    url = "https://tehconnection.eu/torrents.php?torrentname=" + entry["imdb_id"];
     page = task.requests.get(url).content
     soup = get_soup(page)
 


### PR DESCRIPTION
Using searchstr will produce a lot of results that are unrelated to the
given imdb_id. Using torrentname instead will only give us one hit with
the correct movie in the search result.